### PR TITLE
Fix stacktrace encoding

### DIFF
--- a/lib/aws_ex_ray/stacktrace.ex
+++ b/lib/aws_ex_ray/stacktrace.ex
@@ -17,11 +17,15 @@
 
     end
 
-    defp to_map({module, fun, args, [file: path, line: line]}) do
+    def to_map({module, fun, args, [file: path, line: line]}) do
+      arity = cond do
+        is_integer(args) -> args
+        is_list(args) -> length(args)
+      end
       %{
-        path: path,
+        path: "#{path}",
         line: line,
-        label: "#{module}.#{fun_name(fun)}/#{args}"
+        label: "#{module}.#{fun_name(fun)}/#{arity}"
       }
     end
 


### PR DESCRIPTION
Handle the case where the stack trace contains a list of arguments instead of an integer arity.

Encode path as a binary instead of a charlist.

Also export the to_map function, so we can encode stack traces gathered otherwise than from process info.