### PR TITLE
Avoid crashing callers when failing to send a trace

### DIFF
--- a/lib/aws_ex_ray/client/udp_client.ex
+++ b/lib/aws_ex_ray/client/udp_client.ex
@@ -61,9 +61,10 @@ defmodule AwsExRay.Client.UDPClient do
     case send_data(data, state) do
       :ok ->
         {:reply, :ok, state}
-      _other ->
-        Logger.error "<AwsExRay.UDPClient> failed to send data"
-        {:stop, :normal, state}
+      {:error, other} ->
+        Logger.error("<AwsExRay.UDPClient> failed to send data: #{inspect(other)}")
+        # Let's return an :ok reply here, rather than make the caller crash
+        {:stop, :normal, :ok, state}
     end
   end
 


### PR DESCRIPTION
Noticed this happening when the trace document is too big, and the send fails with :emsgsize.  There is no point in crashing the caller in this case; the trace just doesn't get sent.